### PR TITLE
Update Modules Versions to be compatible with AWS Provider >= 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module will create cdn endpoint with alias and SSL-certificate
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.67, < 3.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "certificate" {
 }
 
 module "cloudfront" {
-  source  = "github.com/Flaconi/terraform-aws-cloudfront?ref=v1.0.1"
+  source  = "github.com/terraform-aws-modules/terraform-aws-cloudfront?ref=v1.5.0"
   tags    = var.tags
   aliases = [var.r53_hostname]
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "certificate" {
-  source = "github.com/terraform-aws-modules/terraform-aws-acm?ref=v2.9.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-acm?ref=v2.10.0"
   tags   = var.tags
 
   domain_name = var.r53_hostname

--- a/main.tf
+++ b/main.tf
@@ -37,16 +37,14 @@ module "cloudfront" {
     }
   }
 
-  cache_behavior = {
-    default = {
-      target_origin_id       = "s3_origin"
-      viewer_protocol_policy = "redirect-to-https"
+  default_cache_behavior = {
+    target_origin_id       = "s3_origin"
+    viewer_protocol_policy = "redirect-to-https"
 
-      allowed_methods = ["GET", "HEAD", "OPTIONS"]
-      cached_methods  = ["GET", "HEAD"]
-      compress        = true
-      query_string    = false
-    }
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods  = ["GET", "HEAD"]
+    compress        = true
+    query_string    = false
   }
 
   viewer_certificate = {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "certificate" {
-  source = "github.com/terraform-aws-modules/terraform-aws-acm?ref=v2.10.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-acm?ref=v2.13.0"
   tags   = var.tags
 
   domain_name = var.r53_hostname

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = ">= 2.67, < 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
# Update Modules Versions to be compatible with AWS Provider >= 3.0

## Description
<!-- Add Brief description of what this PR does and why it is needed. -->
Update the acm module version to be compatible with aws provider >=3.0 also change cloudfront module from forked to original and changed the cache_behavior to  be compliant with the latest module version

## Testing Instructions
<!-- Add bullet points for how to test this PR -->
<!-- * What is the desired goal one can test again -->
<!-- * How to test against the desired goal -->
<!-- * Optionally add dry-run instructions -->


## How to roll out
<!-- Add information for how to roll out this PR -->
<!-- * How to roll out (cli or CI/CD tools) -->
<!-- * Where to roll out (affected environments) -->


## Notes
<!-- Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else. -->


## Demo
<!-- Optional. If you have already done a test run, attach your demo output -->

