### PR TITLE
OPS-4711 update the origin s3 bucket policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module will create cdn endpoint with alias and SSL-certificate
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -28,6 +29,11 @@ This module will create cdn endpoint with alias and SSL-certificate
 | Name | Type |
 |------|------|
 | [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_s3_bucket_policy.s3_origin_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [null_resource.either_s3_origin_hostname_or_s3_origin_name_is_required](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.s3_origin_name_is_required_to_override_the_s3_origin_policy](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_iam_policy_document.oai_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_s3_bucket.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 
@@ -35,9 +41,12 @@ This module will create cdn endpoint with alias and SSL-certificate
 |------|-------------|------|---------|:--------:|
 | <a name="input_r53_hostname"></a> [r53\_hostname](#input\_r53\_hostname) | Hostname for CloudFront alias | `string` | n/a | yes |
 | <a name="input_r53_zone_id"></a> [r53\_zone\_id](#input\_r53\_zone\_id) | Route53 zone ID to be used for hostname and certificate validation | `string` | n/a | yes |
-| <a name="input_s3_origin_hostname"></a> [s3\_origin\_hostname](#input\_s3\_origin\_hostname) | Hostname of S3-bucket to be used as origin | `string` | n/a | yes |
 | <a name="input_cdn_logging"></a> [cdn\_logging](#input\_cdn\_logging) | Prefix in s3 bucket for cdn logs | `string` | `""` | no |
+| <a name="input_override_s3_origin_policy"></a> [override\_s3\_origin\_policy](#input\_override\_s3\_origin\_policy) | Overrides the S3-bucket policy to set OAI | `bool` | `false` | no |
 | <a name="input_s3_logging_hostname"></a> [s3\_logging\_hostname](#input\_s3\_logging\_hostname) | Hostname of S3-bucket to be used for logging | `string` | `""` | no |
+| <a name="input_s3_origin_hostname"></a> [s3\_origin\_hostname](#input\_s3\_origin\_hostname) | Hostname of S3-bucket to be used as origin | `string` | `""` | no |
+| <a name="input_s3_origin_name"></a> [s3\_origin\_name](#input\_s3\_origin\_name) | Name of S3-bucket to be used as origin | `string` | `""` | no |
+| <a name="input_s3_origin_policy_restrict_access"></a> [s3\_origin\_policy\_restrict\_access](#input\_s3\_origin\_policy\_restrict\_access) | Folder/files to add as an condition to the S3-bucket policy resource | `string` | `"/*"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of custom tags for the provisioned resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,13 @@
 variable "s3_origin_hostname" {
   description = "Hostname of S3-bucket to be used as origin"
   type        = string
+  default     = ""
+}
+
+variable "s3_origin_name" {
+  description = "Name of S3-bucket to be used as origin"
+  type        = string
+  default     = ""
 }
 
 variable "s3_logging_hostname" {
@@ -29,4 +36,16 @@ variable "tags" {
   description = "Map of custom tags for the provisioned resources"
   type        = map(string)
   default     = {}
+}
+
+variable "override_s3_origin_policy" {
+  description = "Overrides the S3-bucket policy to set OAI"
+  type        = bool
+  default     = false
+}
+
+variable "s3_origin_policy_restrict_access" {
+  description = "Folder/files to add as an condition to the S3-bucket policy resource"
+  type        = string
+  default     = "/*"
 }


### PR DESCRIPTION
# Update the origin s3 bucket policy

## Description
Configures the S3 bucket permissions that CloudFront can use the OAI to access the files in the bucket and serve them to the users.


## Testing Instructions
The module is used to create a cdn to serve the product feeds generated by Productsup and our custom lambda function in the following lite-infra branch. 
https://github.com/Flaconi/lite-infra/blob/PIMF-1474/terragrunt/envs/aws/stage/eu-central-1/applications/ct-product-feed/feed-cdn/terragrunt.hcl

## How to roll out
After PR approval the release tag is created and the relevant tag is updated in the branch PIMF-1474 of lite-infra repository.

## Demo
The created product feed can be accessible via CDN 
(https://product-feed.stage.flaconi-platform.net/export/yotpo_de.csv)
but not direct access to the s3 bucket 
(https://stage-ct-product-feed.s3.eu-central-1.amazonaws.com/export/yotpo_de.csv)

